### PR TITLE
move save_inventory's disconnects to ems/vm

### DIFF
--- a/app/models/providers/infra/host.rb
+++ b/app/models/providers/infra/host.rb
@@ -21,6 +21,10 @@ module Providers
     has_many   :vms, :inverse_of => :host
     has_many   :templates, :inverse_of => :host
 
+    def disconnects
+      vms_and_templates
+    end
+
     alias_attribute     :state,   :power_state
     alias_attribute     :to_s,    :name
 

--- a/app/models/providers/infra/vm.rb
+++ b/app/models/providers/infra/vm.rb
@@ -1,4 +1,7 @@
 module Providers
   class Infra::Vm < Infra::VmOrTemplate
+    def disconnects
+      ruby_clone
+    end
   end
 end


### PR DESCRIPTION
So that cloud/infra manager can return proper objects

Related: 
* refresh: https://github.com/agrare/foreman_providers/pull/9
* [openstack manager side](https://github.com/jameswnl/foreman_providers_openstack/blob/master/app/models/providers/openstack/manager.rb#L8)
